### PR TITLE
Prevent a forwardable error.

### DIFF
--- a/lib/proximity_beacon.rb
+++ b/lib/proximity_beacon.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'uri'
 require 'net/http'
 require 'base64'
+require 'forwardable'
 
 require "proximity_beacon/version"
 require "proximity_beacon/client"


### PR DESCRIPTION
Was getting an error trying to load the gem;

```
[93%]diff@rocksteady:[proximity_beacon_gem] $ gem install proximity_beacon
Successfully installed proximity_beacon-0.1.1
Parsing documentation for proximity_beacon-0.1.1
Done installing documentation for proximity_beacon after 0 seconds
1 gem installed
[94%]diff@rocksteady:[proximity_beacon_gem] $ irb
2.2.3 :001 > require 'proximity_beacon'
NameError: uninitialized constant ProximityBeacon::Client::Request::Forwardable
    from /Users/diff/.rvm/gems/ruby-2.2.3/gems/proximity_beacon-0.1.1/lib/proximity_beacon/client/request.rb:8:in `<class:Request>'
    from /Users/diff/.rvm/gems/ruby-2.2.3/gems/proximity_beacon-0.1.1/lib/proximity_beacon/client/request.rb:7:in `<class:Client>'
    from /Users/diff/.rvm/gems/ruby-2.2.3/gems/proximity_beacon-0.1.1/lib/proximity_beacon/client/request.rb:6:in `<module:ProximityBeacon>'
    from /Users/diff/.rvm/gems/ruby-2.2.3/gems/proximity_beacon-0.1.1/lib/proximity_beacon/client/request.rb:5:in `<top (required)>'
    from /Users/diff/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/diff/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/diff/.rvm/gems/ruby-2.2.3/gems/proximity_beacon-0.1.1/lib/proximity_beacon.rb:11:in `<top (required)>'
    from /Users/diff/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `require'
    from /Users/diff/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
    from /Users/diff/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:39:in `require'
    from (irb):1
    from /Users/diff/.rvm/rubies/ruby-2.2.3/bin/irb:15:in `<main>'
```

```
[96%]diff@rocksteady:[proximity_beacon_gem] $ ruby --version
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin14]
```
